### PR TITLE
Martini integration utilities

### DIFF
--- a/.github/workflows/SwiftPol_tests.yml
+++ b/.github/workflows/SwiftPol_tests.yml
@@ -89,3 +89,11 @@ jobs:
         pip install -e .
         pip install pytest pytest-cov        
         pytest tests/crosslink_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+
+    - name: utils tests
+      run: |
+        source ~/.bashrc
+        conda activate swiftpol
+        pip install -e .
+        pip install pytest pytest-cov        
+        pytest tests/utils_tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/swiftpol/build.py
+++ b/swiftpol/build.py
@@ -1455,12 +1455,12 @@ class polymer_system:
                 sigma = np.sqrt(np.log(1.05))
                 mu = np.log(self.length_target * 0.1) - 0.5 * sigma**2
                 chain_lengths = np.random.lognormal(mu, sigma, size=1)
-                chain_lengths = np.round(chain_lengths).astype(int)
+                chain_lengths = np.round(chain_lengths).astype(int)[0]  # Extract scalar value
                 oligo_seq = reduce(
                     lambda x, y: x + y,
                     np.random.choice(
                         ["A", "B"],
-                        size=(int(chain_lengths)),
+                        size=chain_lengths,  # Use the scalar value here
                         p=[self.A_target / 100, 1 - (self.A_target / 100)],
                     ),
                 )
@@ -1499,7 +1499,7 @@ class polymer_system:
             number_of_copies = [A_to_add, B_to_add] + [1 for c in range(len(oligomers))]
 
         elif "A" in sequence and "B" not in sequence:
-            for i in range(1000):
+            for i in range(10000):
                 sigma = np.sqrt(np.log(1.05))
                 mu = np.log(self.length_target * 0.1) - 0.5 * sigma**2
                 chain_lengths = np.random.lognormal(mu, sigma, size=1)
@@ -2370,12 +2370,12 @@ class polymer_system_from_PDI:
                 sigma = np.sqrt(np.log(1.05))
                 mu = np.log(self.length_target * 0.1) - 0.5 * sigma**2
                 chain_lengths = np.random.lognormal(mu, sigma, size=1)
-                chain_lengths = np.round(chain_lengths).astype(int)
+                chain_lengths = np.round(chain_lengths).astype(int)[0]  # Extract scalar value
                 oligo_seq = reduce(
                     lambda x, y: x + y,
                     np.random.choice(
                         ["A", "B"],
-                        size=(int(chain_lengths)),
+                        size=chain_lengths,  # Use the scalar value here
                         p=[self.A_target / 100, 1 - (self.A_target / 100)],
                     ),
                 )
@@ -2414,7 +2414,7 @@ class polymer_system_from_PDI:
             number_of_copies = [A_to_add, B_to_add] + [1 for c in range(len(oligomers))]
 
         elif "A" in sequence and "B" not in sequence:
-            for i in range(1000):
+            for i in range(10000):
                 sigma = np.sqrt(np.log(1.05))
                 mu = np.log(self.length_target * 0.1) - 0.5 * sigma**2
                 chain_lengths = np.random.lognormal(mu, sigma, size=1)

--- a/swiftpol/build.py
+++ b/swiftpol/build.py
@@ -2391,7 +2391,6 @@ class polymer_system_from_PDI:
                     chain_num=len(self.chains) + 1 + i,
                     terminal=self.terminals,                
                 )
-                #oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
                 oligomer.name = "oligo" + str(len(self.chains) + 1 + i)
                 oligo_mass = 0
@@ -2433,7 +2432,6 @@ class polymer_system_from_PDI:
                     chain_num=len(self.chains) + 1 + i,
                     terminal=self.terminals,                    
                 )
-                #oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
                 oligomer.name = "oligo" + str(len(self.chains) + 1 + i)
                 oligo_mass = 0

--- a/swiftpol/build.py
+++ b/swiftpol/build.py
@@ -167,6 +167,8 @@ def build_polymer(
         info.SetChainId(chainID)
         [atom.SetMonomerInfo(info) for atom in carboxyl.GetAtoms()]
         polymer = Chem.ReplaceSubstructs(polymer, Chem.MolFromSmarts("[At]"), carboxyl)[0]
+        Chem.SanitizeMol(polymer)
+        Chem.AddHs(polymer)
     elif terminal == "ester":
         carbon = Chem.MolFromSmiles("[CH3]")
         carbon = Chem.AddHs(carbon)
@@ -1470,6 +1472,7 @@ class polymer_system:
                     monomer_list=monomer_list,
                     reaction=AllChem.ReactionFromSmarts(self.reaction),
                     chain_num=len(self.chains) + 1 + i,
+                    terminal=self.terminals,
                 )
                 oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
@@ -1511,6 +1514,7 @@ class polymer_system:
                     monomer_list=monomer_list,
                     reaction=AllChem.ReactionFromSmarts(self.reaction),
                     chain_num=len(self.chains) + 1 + i,
+                    terminal=self.terminals,
                 )
                 oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
@@ -2385,8 +2389,9 @@ class polymer_system_from_PDI:
                     monomer_list=monomer_list,
                     reaction=AllChem.ReactionFromSmarts(self.reaction),
                     chain_num=len(self.chains) + 1 + i,
+                    terminal=self.terminals,                
                 )
-                oligomer_rd = Chem.AddHs(oligomer_rd)
+                #oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
                 oligomer.name = "oligo" + str(len(self.chains) + 1 + i)
                 oligo_mass = 0
@@ -2426,8 +2431,9 @@ class polymer_system_from_PDI:
                     monomer_list=monomer_list,
                     reaction=AllChem.ReactionFromSmarts(self.reaction),
                     chain_num=len(self.chains) + 1 + i,
+                    terminal=self.terminals,                    
                 )
-                oligomer_rd = Chem.AddHs(oligomer_rd)
+                #oligomer_rd = Chem.AddHs(oligomer_rd)
                 oligomer = Molecule.from_rdkit(oligomer_rd)
                 oligomer.name = "oligo" + str(len(self.chains) + 1 + i)
                 oligo_mass = 0

--- a/swiftpol/utils.py
+++ b/swiftpol/utils.py
@@ -11,8 +11,12 @@ def perceive_sequences(sys):
         residue_names = []
         for atom in polymer.GetAtoms():
             info = atom.GetPDBResidueInfo()
-            residue_names.append(info.GetResidueName())
-            residue_ids.append(info.GetResidueNumber())
+            try:
+                residue_names.append(info.GetResidueName())
+                residue_ids.append(info.GetResidueNumber())
+            except:
+                warnings.warn(f"Atom {atom.GetIdx()} in chain {chain_id} does not have valid residue information. Skipping this atom.")
+                continue
         residue_ids_dict = {residue_ids[i]: residue_names[i] for i in range(len(residue_ids))} 
         for i in residue_ids_dict:
             if residue_ids_dict[i].find('A') > 0:

--- a/swiftpol/utils.py
+++ b/swiftpol/utils.py
@@ -3,6 +3,7 @@
 
 # Perceive sequences
 def perceive_sequences(sys):
+    import warnings
     sequence_dict = {}
     for polymer in sys.chain_rdkit:
         chain_id = sys.chain_rdkit.index(polymer)
@@ -12,46 +13,103 @@ def perceive_sequences(sys):
             info = atom.GetPDBResidueInfo()
             residue_names.append(info.GetResidueName())
             residue_ids.append(info.GetResidueNumber())
-        residue_ids_dict = {residue_ids[i]:residue_names[i] for i in range(len(residue_ids))} 
+        residue_ids_dict = {residue_ids[i]: residue_names[i] for i in range(len(residue_ids))} 
         for i in residue_ids_dict:
-            if residue_ids_dict[i].find('A')>0:
+            if residue_ids_dict[i].find('A') > 0:
                 residue_ids_dict[i] = 'A'
-            elif residue_ids_dict[i].find('B')>0:
+            elif residue_ids_dict[i].find('B') > 0:
                 residue_ids_dict[i] = 'B'
-            elif residue_ids_dict[i].find('C')>0:
+            elif residue_ids_dict[i].find('C') > 0:
                 residue_ids_dict[i] = 'C'       
-            elif residue_ids_dict[i].find('D')>0:
+            elif residue_ids_dict[i].find('D') > 0:
                 residue_ids_dict[i] = 'D' 
-            elif residue_ids_dict[i].find('S')>0:
+            elif residue_ids_dict[i].find('S') > 0:
                 residue_ids_dict[i] = 'S'                               
         sorted_residue_ids_dict = dict(sorted(residue_ids_dict.items(), key=lambda item: int(item[0])))
         sequence = ''.join(sorted_residue_ids_dict.values())
+        # Terminal info for ester and carboxyl groups
+        if sys.terminals:
+            if sys.terminals == 'ester':
+                sequence += 'Z'
+            elif sys.terminals == 'carboxyl':
+                sequence += 'X'
+            else:
+                warnings.warn(f"Unsupported terminal type '{sys.terminals}'. No terminal information will be appended to the sequence.")
+        
         sequence_dict[chain_id] = sequence
+
     return sequence_dict
 
 
-def export_seq_to_json(dict_seq, resname_map, chirality_map = {"A": "S", "S": "R", "B":"S"}):
+def export_seq_to_json(dict_seq, resname_map, chirality_map={"A": "S", "S": "R", "B": "S"}, terminals_map={"Z": "E", "X": "C"}):
+    """
+    Export sequences to JSON format with support for terminals.
+
+    Parameters
+    ----------
+    dict_seq : dict
+        Dictionary of sequences where keys are sequence IDs and values are sequences.
+    resname_map : dict
+        Mapping of sequence letters to residue names.
+    chirality_map : dict, optional
+        Mapping of sequence letters to chirality (default: {"A": "S", "S": "R", "B": "S"}).
+    terminals_map : dict, optional
+        Mapping of terminal names to their corresponding sequence letters (default: {"ESTER": "E", "ACID": "C"}).
+    """
     import json
+
     for s in dict_seq:
         sequence = dict_seq[s]
         nodes = []
         edges = []
-    
-        # build nodes
+
+        # Check for terminals at the start and end of the sequence
+        start_terminal = None
+        end_terminal = None
+
+        if sequence.startswith(tuple(terminals_map.values())):
+            start_terminal = sequence[0]
+            sequence = sequence[1:]  # Remove the start terminal from the sequence
+
+        if sequence.endswith(tuple(terminals_map.values())):
+            end_terminal = sequence[-1]
+            sequence = sequence[:-1]  # Remove the end terminal from the sequence
+
+        # Build nodes
         for i, letter in enumerate(sequence):
             nodes.append({
                 "resname": resname_map[letter],
                 "seqid": 0,
-                "chiral": chirality_map[letter],
+                "chiral": chirality_map.get(letter, None),  # Default to None if chirality is not defined
                 "id": i
             })
-        # build linear edges
-        for i in range(len(sequence) - 1):
+
+        # Add start terminal as the first node, if present
+        if start_terminal:
+            nodes.insert(0, {
+                "resname": resname_map[start_terminal],
+                "seqid": -1,  # Use -1 for terminal residues
+                "chiral": None,  # Terminals typically don't have chirality
+                "id": 0
+            })
+
+        # Add end terminal as the last node, if present
+        if end_terminal:
+            nodes.append({
+                "resname": resname_map[end_terminal],
+                "seqid": len(sequence),  # Use the sequence length as the ID for the end terminal
+                "chiral": None,
+                "id": len(nodes)  # ID is the current length of the nodes list
+            })
+
+        # Build linear edges
+        for i in range(len(nodes) - 1):
             edges.append({
                 "source": i,
                 "target": i + 1
             })
-        # full graph structure
+
+        # Full graph structure
         graph = {
             "directed": False,
             "multigraph": False,
@@ -60,7 +118,6 @@ def export_seq_to_json(dict_seq, resname_map, chirality_map = {"A": "S", "S": "R
             "edges": edges
         }
 
-        # write to json file
+        # Write to JSON file
         with open(f"sequence_{s}.json", "w") as f:
             json.dump(graph, f, indent=2)
-    

--- a/swiftpol/utils.py
+++ b/swiftpol/utils.py
@@ -1,0 +1,66 @@
+### Utilities for Swiftpol/Polyply MARTINI builder
+### Under development
+
+# Perceive sequences
+def perceive_sequences(sys):
+    sequence_dict = {}
+    for polymer in sys.chain_rdkit:
+        chain_id = sys.chain_rdkit.index(polymer)
+        residue_ids = []
+        residue_names = []
+        for atom in polymer.GetAtoms():
+            info = atom.GetPDBResidueInfo()
+            residue_names.append(info.GetResidueName())
+            residue_ids.append(info.GetResidueNumber())
+        residue_ids_dict = {residue_ids[i]:residue_names[i] for i in range(len(residue_ids))} 
+        for i in residue_ids_dict:
+            if residue_ids_dict[i].find('A')>0:
+                residue_ids_dict[i] = 'A'
+            elif residue_ids_dict[i].find('B')>0:
+                residue_ids_dict[i] = 'B'
+            elif residue_ids_dict[i].find('C')>0:
+                residue_ids_dict[i] = 'C'       
+            elif residue_ids_dict[i].find('D')>0:
+                residue_ids_dict[i] = 'D' 
+            elif residue_ids_dict[i].find('S')>0:
+                residue_ids_dict[i] = 'S'                               
+        sorted_residue_ids_dict = dict(sorted(residue_ids_dict.items(), key=lambda item: int(item[0])))
+        sequence = ''.join(sorted_residue_ids_dict.values())
+        sequence_dict[chain_id] = sequence
+    return sequence_dict
+
+
+def export_seq_to_json(dict_seq, resname_map, chirality_map = {"A": "S", "S": "R", "B":"S"}):
+    import json
+    for s in dict_seq:
+        sequence = dict_seq[s]
+        nodes = []
+        edges = []
+    
+        # build nodes
+        for i, letter in enumerate(sequence):
+            nodes.append({
+                "resname": resname_map[letter],
+                "seqid": 0,
+                "chiral": chirality_map[letter],
+                "id": i
+            })
+        # build linear edges
+        for i in range(len(sequence) - 1):
+            edges.append({
+                "source": i,
+                "target": i + 1
+            })
+        # full graph structure
+        graph = {
+            "directed": False,
+            "multigraph": False,
+            "graph": {},
+            "nodes": nodes,
+            "edges": edges
+        }
+
+        # write to json file
+        with open(f"sequence_{s}.json", "w") as f:
+            json.dump(graph, f, indent=2)
+    

--- a/swiftpol/utils.py
+++ b/swiftpol/utils.py
@@ -5,8 +5,7 @@
 def perceive_sequences(sys):
     import warnings
     sequence_dict = {}
-    for polymer in sys.chain_rdkit:
-        chain_id = sys.chain_rdkit.index(polymer)
+    for chain_id, polymer in enumerate(sys.chain_rdkit):
         residue_ids = []
         residue_names = []
         for atom in polymer.GetAtoms():

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,0 +1,47 @@
+import unittest
+import json
+from swiftpol import utils
+from swiftpol import build
+import os
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_perceive_sequences(self):
+        sys = build.polymer_system_from_PDI(
+            monomer_list=["OC(=O)COI"],
+            reaction="[C:1][O:2][H:3].[I:4][O:5][C:6]>>[C:1][O:2][C:6].[H:3][O:5][I:4]",
+            length_target=50,
+            num_chains=50,
+            terminals='ester',
+            PDI_target=1.7,
+            copolymer=False,
+            acceptance=20,
+        )
+
+        sequences_dict = utils.perceive_sequences(sys)
+        self.assertEqual(len(sequences_dict), 50)
+        self.assertEqual(sequences_dict[0][-1], "Z")
+
+
+    def test_export_seq_to_json(self):
+        sys = build.polymer_system_from_PDI(
+            monomer_list=["OC(=O)COI"],
+            reaction="[C:1][O:2][H:3].[I:4][O:5][C:6]>>[C:1][O:2][C:6].[H:3][O:5][I:4]",
+            length_target=50,
+            num_chains=50,
+            terminals='ester',
+            PDI_target=1.7,
+            copolymer=False,
+            acceptance=20,
+        )
+
+        sequences_dict = utils.perceive_sequences(sys)
+        utils.export_seq_to_json(sequences_dict, resname_map={"A": "LAL", "B": "GA", "S":"LAD", "Z":'ESTER'})
+
+        for i in range(len(sequences_dict)):
+            file_name = f'sequence_{i}.json'
+            self.assertTrue(os.path.exists(file_name), f"File {file_name} does not exist.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added:
- swiftpol.utils module to introduce functions to export Swiftpol ensemble objects to files required for building coarse grained models through polyply.
- FIxed minor atom naming bug in swiftpol.build for acid/carboxyl terminated polymers
